### PR TITLE
fixing contract id validation in decodeOperation

### DIFF
--- a/src/Contract.ts
+++ b/src/Contract.ts
@@ -390,7 +390,7 @@ export class Contract {
     if (!this.serializer) throw new Error("Serializer is not defined");
     if (!op.call_contract)
       throw new Error("Operation is not CallContractOperation");
-    if (op.call_contract.contract_id !== this.id)
+    if (encodeBase58(op.call_contract.contract_id) !== encodeBase58(this.id))
       throw new Error(
         `Invalid contract id. Expected: ${encodeBase58(
           this.id


### PR DESCRIPTION
it looks like Uint8Array are objects in javascript and the '===' is not working, I propose to do the comparison on the base58 encoded version of the contract id (using encodeBase58)